### PR TITLE
[DXP-842] Validate docker environment

### DIFF
--- a/core/src/main/java/dev/streamx/cli/ExceptionHandler.java
+++ b/core/src/main/java/dev/streamx/cli/ExceptionHandler.java
@@ -16,12 +16,15 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
   @Override
   public int handleExecutionException(Exception ex, CommandLine cmd,
       ParseResult parseResult) {
-
-    cmd.getErr().println(cmd.getColorScheme().errorText(ex.getMessage()));
-    log.error("Execution exception occurred.", ex);
+    Throwable throwable = ex;
+    if (ex instanceof CommandLine.ExecutionException e) {
+      throwable = e.getCause();
+    }
+    cmd.getErr().println(cmd.getColorScheme().errorText(throwable.getMessage()));
+    log.error("Execution exception occurred.", throwable);
 
     return cmd.getExitCodeExceptionMapper() == null
         ? cmd.getCommandSpec().exitCodeOnExecutionException()
-        : cmd.getExitCodeExceptionMapper().getExitCode(ex);
+        : cmd.getExitCodeExceptionMapper().getExitCode(throwable);
   }
 }

--- a/core/src/main/java/dev/streamx/cli/ExceptionHandler.java
+++ b/core/src/main/java/dev/streamx/cli/ExceptionHandler.java
@@ -16,15 +16,19 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
   @Override
   public int handleExecutionException(Exception ex, CommandLine cmd,
       ParseResult parseResult) {
-    Throwable throwable = ex;
-    if (ex instanceof CommandLine.ExecutionException e) {
-      throwable = e.getCause();
-    }
-    cmd.getErr().println(cmd.getColorScheme().errorText(throwable.getMessage()));
-    log.error("Execution exception occurred.", throwable);
+    printErrorMessage(ex, cmd);
+    log.error("Execution exception occurred.", ex);
 
     return cmd.getExitCodeExceptionMapper() == null
         ? cmd.getCommandSpec().exitCodeOnExecutionException()
-        : cmd.getExitCodeExceptionMapper().getExitCode(throwable);
+        : cmd.getExitCodeExceptionMapper().getExitCode(ex);
+  }
+
+  private static void printErrorMessage(Exception ex, CommandLine cmd) {
+    Throwable exceptionCause = ex;
+    if (ex instanceof CommandLine.ExecutionException e && e.getCause() != null) {
+      exceptionCause = e.getCause();
+    }
+    cmd.getErr().println(cmd.getColorScheme().errorText(exceptionCause.getMessage()));
   }
 }

--- a/core/src/main/java/dev/streamx/cli/exception/DockerException.java
+++ b/core/src/main/java/dev/streamx/cli/exception/DockerException.java
@@ -1,0 +1,80 @@
+package dev.streamx.cli.exception;
+
+import dev.streamx.runner.validation.excpetion.DockerContainerNonUniqueException.ContainerStatus;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+public class DockerException extends RuntimeException {
+
+  private DockerException(String message, Exception exception) {
+    super(message, exception);
+  }
+
+  private DockerException(String message) {
+    super(message);
+  }
+
+  public static DockerException dockerEnvironmentException() {
+    return new DockerException("""
+        Could not find a valid Docker environment. Check logs for details.
+
+        Make sure that:
+         * Docker is installed,
+         * Docker is running
+         """);
+  }
+
+  public static DockerException nonUniqueContainersException(
+      List<ContainerStatus> containerStatus) {
+    String runningContainersFragment = generateRunningContainersFragment(containerStatus);
+    String nonRunningContainersToRemove = generateContainersToRemoveFragment(containerStatus);
+
+    String template = """
+        StreamX needs to start containers, but some of containers with same names already exists.
+        
+        %s%s""".formatted(runningContainersFragment, nonRunningContainersToRemove);
+
+    return new DockerException(template);
+  }
+
+  @NotNull
+  private static String generateContainersToRemoveFragment(List<ContainerStatus> containerStatus) {
+    List<ContainerStatus> nonRunningContainers = containerStatus.stream()
+        .filter(cs -> !"running".equals(cs.state()))
+        .toList();
+
+    String nonRunningContainersAsString = nonRunningContainers.stream()
+        .map(cs -> " * " + cs.name() + " in status " + cs.state() + " " + fromMeshFragment(cs))
+        .collect(Collectors.joining("\n"));
+
+    return !nonRunningContainers.isEmpty()
+        ? "Please remove these containers:\n"
+            + nonRunningContainersAsString
+            + "\n"
+        : "";
+  }
+
+  @NotNull
+  private static String generateRunningContainersFragment(List<ContainerStatus> containerStatus) {
+    List<ContainerStatus> runningContainers = containerStatus.stream()
+        .filter(cs -> "running".equals(cs.state()))
+        .toList();
+
+    String runningContainersAsString = runningContainers.stream()
+        .map(cs -> " * " + cs.name() + " " + fromMeshFragment(cs))
+        .collect(Collectors.joining("\n"));
+
+    return !runningContainers.isEmpty()
+        ? "Maybe you already launched StreamX mesh? "
+            + "Check running containers:\n"
+            + runningContainersAsString
+            + "\n"
+        : "";
+  }
+
+  @NotNull
+  private static String fromMeshFragment(ContainerStatus cs) {
+    return cs.meshPath() != null ? "(from mesh " + cs.meshPath() + ")" : "";
+  }
+}

--- a/core/src/main/java/dev/streamx/cli/exception/DockerException.java
+++ b/core/src/main/java/dev/streamx/cli/exception/DockerException.java
@@ -65,8 +65,8 @@ public class DockerException extends RuntimeException {
         Mesh definition:
         %s
 
-        Consider reusing the running mesh \
-        or removing containers before running the StreamX Mesh again."""
+        Stop the running mesh \
+        or remove containers of the running Mesh before starting new StreamX Mesh."""
         .formatted(commonMesh);
 
     return new DockerException(message);

--- a/core/src/main/java/dev/streamx/cli/exception/DockerException.java
+++ b/core/src/main/java/dev/streamx/cli/exception/DockerException.java
@@ -30,7 +30,7 @@ public class DockerException extends RuntimeException {
     String nonRunningContainersToRemove = generateContainersToRemoveFragment(containerStatus);
 
     String template = """
-        StreamX needs to start containers, but some of containers with same names already exists.
+        StreamX needs to start containers, but there are already containers with the same names.
         
         %s%s"""
         .formatted(runningContainersFragment, nonRunningContainersToRemove)

--- a/core/src/main/java/dev/streamx/cli/exception/DockerException.java
+++ b/core/src/main/java/dev/streamx/cli/exception/DockerException.java
@@ -21,8 +21,7 @@ public class DockerException extends RuntimeException {
 
         Make sure that:
          * Docker is installed,
-         * Docker is running
-         """);
+         * Docker is running""");
   }
 
   public static DockerException nonUniqueContainersException(
@@ -33,7 +32,9 @@ public class DockerException extends RuntimeException {
     String template = """
         StreamX needs to start containers, but some of containers with same names already exists.
         
-        %s%s""".formatted(runningContainersFragment, nonRunningContainersToRemove);
+        %s%s"""
+        .formatted(runningContainersFragment, nonRunningContainersToRemove)
+        .trim();
 
     return new DockerException(template);
   }

--- a/core/src/main/java/dev/streamx/cli/exception/DockerException.java
+++ b/core/src/main/java/dev/streamx/cli/exception/DockerException.java
@@ -66,7 +66,7 @@ public class DockerException extends RuntimeException {
         %s
 
         Stop the running mesh \
-        or remove containers of the running Mesh before starting new StreamX Mesh."""
+        or remove containers of the running mesh before starting a new StreamX Mesh."""
         .formatted(commonMesh);
 
     return new DockerException(message);

--- a/core/src/main/java/dev/streamx/cli/run/RunCommand.java
+++ b/core/src/main/java/dev/streamx/cli/run/RunCommand.java
@@ -54,17 +54,19 @@ public class RunCommand implements Runnable {
       print("Setting up system containers...");
 
       try {
-        this.runner.startBase(new RunnerRequest(result.serviceMesh(), meshPath));
+        this.runner.initialize(new RunnerRequest(result.serviceMesh(), meshPath));
       } catch (DockerContainerNonUniqueException e) {
         throw DockerException.nonUniqueContainersException(e.getContainers());
       } catch (DockerEnvironmentException e) {
         throw DockerException.dockerEnvironmentException();
       }
 
+      this.runner.startBase();
+
       print("");
       print("Starting DX Mesh...");
 
-      this.runner.startMesh(new RunnerRequest(result.serviceMesh(), meshPath));
+      this.runner.startMesh();
 
       printSummary(this.runner, result.path());
       Quarkus.waitForExit();

--- a/core/src/main/java/dev/streamx/cli/run/RunCommand.java
+++ b/core/src/main/java/dev/streamx/cli/run/RunCommand.java
@@ -6,7 +6,6 @@ import dev.streamx.cli.exception.DockerException;
 import dev.streamx.cli.run.MeshDefinitionResolver.MeshDefinition;
 import dev.streamx.runner.StreamxRunner;
 import dev.streamx.runner.event.ContainerStarted;
-import dev.streamx.runner.model.RunnerRequest;
 import dev.streamx.runner.validation.excpetion.DockerContainerNonUniqueException;
 import dev.streamx.runner.validation.excpetion.DockerEnvironmentException;
 import io.quarkus.runtime.Quarkus;
@@ -54,7 +53,7 @@ public class RunCommand implements Runnable {
       print("Setting up system containers...");
 
       try {
-        this.runner.initialize(new RunnerRequest(result.serviceMesh(), meshPath));
+        this.runner.initialize(result.serviceMesh(), meshPath);
       } catch (DockerContainerNonUniqueException e) {
         throw DockerException.nonUniqueContainersException(e.getContainers());
       } catch (DockerEnvironmentException e) {

--- a/core/src/main/java/dev/streamx/cli/run/TestContainerLogFilter.java
+++ b/core/src/main/java/dev/streamx/cli/run/TestContainerLogFilter.java
@@ -14,6 +14,10 @@ public class TestContainerLogFilter implements Filter {
   public boolean isLoggable(LogRecord record) {
     Level level = record.getLevel();
 
+    return isImagePullLog(record, level);
+  }
+
+  private static boolean isImagePullLog(LogRecord record, Level level) {
     return level.intValue() >= Level.WARNING.intValue() || Stream.of(
             "Pulling image",
             "Pull complete.",

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -21,5 +21,4 @@ streamx.cli.settings.root-dir=${user.home}/.streamx
 %prod.quarkus.log.category."tc".level=INFO
 %prod.quarkus.log.handler.console.dockerapi.format=\u0020\u0020\u0020\u0020%s%e%n
 %prod.quarkus.log.category."com.github.dockerjava.api".handlers=dockerapi
-%prod.quarkus.log.category."com.github.dockerjava.api".use-parent-handlers=false
 %prod.quarkus.log.category."com.github.dockerjava.api".level=ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.7.4</quarkus.platform.version>
 
-    <streamx.version>0.0.22-SNAPSHOT</streamx.version> <!-- FIXME -->
+    <streamx.version>0.0.23-SNAPSHOT</streamx.version> <!-- FIXME -->
     <json-path.version>2.9.0</json-path.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <wiremock.version>3.3.1</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.7.4</quarkus.platform.version>
 
-    <streamx.version>0.0.20</streamx.version>
+    <streamx.version>0.0.22-SNAPSHOT</streamx.version> <!-- FIXME -->
     <json-path.version>2.9.0</json-path.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <wiremock.version>3.3.1</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.7.4</quarkus.platform.version>
 
-    <streamx.version>0.0.23-SNAPSHOT</streamx.version> <!-- FIXME -->
+    <streamx.version>0.0.23</streamx.version>
     <json-path.version>2.9.0</json-path.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <wiremock.version>3.3.1</wiremock.version>


### PR DESCRIPTION
Added docker environment feature.

1.If docker is not installed or running. User will see:
```
Could not find a valid Docker environment. Check logs for details.

Make sure that:
 * Docker is installed,
 * Docker is running
```
2.If there are docker containers with same names as StreamX wants to start user will see:
```
StreamX tries to start Docker containers. It looks like
 * grafana
 * jaeger
names are already in use. Remove or rename the containers with these names before restarting StreamX Mesh.
```
Or
```
It looks like some StreamX Mesh is already running. Mesh definition:
/Users/jakubgardo/repo/streamx-cli/core/target/test-classes/streamx-mesh.yml

Consider reusing the running mesh or removing containers before running the StreamX Mesh again.
```