### PR TITLE
[DXP-1493] Make mesh manager explicitly public

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
     <quarkus.package.main-class>dev.streamx.cli.StreamxCommand</quarkus.package.main-class>
 
     <!-- this should not be overridden by user, same as streamx runner dependencies -->
-    <streamx.manager.mesh-manager.image>ghcr.io/streamx-dev/streamx-mesh-manager/streamx-mesh-manager:0.0.1-jvm</streamx.manager.mesh-manager.image>
+    <streamx.manager.mesh-manager.image>ghcr.io/streamx-dev/streamx-mesh-manager/streamx-mesh-manager:FIXME-jvm</streamx.manager.mesh-manager.image>
   </properties>
 
   <dependencies>

--- a/core/src/main/java/dev/streamx/cli/command/manager/ManagerCommand.java
+++ b/core/src/main/java/dev/streamx/cli/command/manager/ManagerCommand.java
@@ -26,7 +26,6 @@ import picocli.CommandLine.Command;
 @Command(name = ManagerCommand.COMMAND_NAME,
     mixinStandardHelpOptions = true,
     versionProvider = VersionProvider.class,
-    hidden = true, // FIXME change after official release of StreamX Mesh Manager
     description = "Serve StreamX Mesh Manager locally.")
 public class ManagerCommand implements Runnable {
 


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [x] Non-breaking change
- [ ] Bug fix / minor change

## 🛠 Changes being made

* `streamx manager` is no longer hidden in help
* Bump streamx-mesh-manager version

## ✅ Checklist

- [ ] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [ ] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
