### PR TITLE
[DXP-1500] Downgrade avro version to match streamx-ingestion-client

### DIFF
--- a/core/src/main/java/dev/streamx/cli/command/ingestion/publish/payload/typed/TypedPayloadFragmentResolver.java
+++ b/core/src/main/java/dev/streamx/cli/command/ingestion/publish/payload/typed/TypedPayloadFragmentResolver.java
@@ -1,17 +1,20 @@
 package dev.streamx.cli.command.ingestion.publish.payload.typed;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import dev.streamx.cli.command.ingestion.PayloadProcessing;
 import dev.streamx.cli.command.ingestion.publish.payload.source.RawPayload;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.apache.avro.util.internal.JacksonUtils;
 
 @ApplicationScoped
 public class TypedPayloadFragmentResolver {
+
+  private static final ObjectMapper BINARY_SERIALIZATION_OBJECT_MAPPER = new ObjectMapper();
 
   @Inject
   @PayloadProcessing
@@ -22,12 +25,24 @@ public class TypedPayloadFragmentResolver {
     final byte[] bytes = rawPayload.source();
     return switch (sourceType) {
       case JSON -> new TypedPayload(objectMapper.readTree(bytes));
-      case BINARY -> new TypedPayload(JacksonUtils.toJsonNode(bytes));
+      case BINARY -> new TypedPayload(toJsonNode(bytes));
       case STRING -> {
         String content = new String(bytes, StandardCharsets.UTF_8);
 
         yield new TypedPayload(TextNode.valueOf(content));
       }
     };
+  }
+
+  private static JsonNode toJsonNode(byte[] datum) throws IOException {
+    if (datum == null) {
+      return null;
+    }
+
+    try (var generator = new TokenBuffer(BINARY_SERIALIZATION_OBJECT_MAPPER, false)) {
+      generator.writeString(new String(datum, StandardCharsets.ISO_8859_1));
+
+      return BINARY_SERIALIZATION_OBJECT_MAPPER.readTree(generator.asParser());
+    }
   }
 }

--- a/core/src/test/java/dev/streamx/cli/command/ingestion/publish/PublishCommandTest.java
+++ b/core/src/test/java/dev/streamx/cli/command/ingestion/publish/PublishCommandTest.java
@@ -135,11 +135,28 @@ public class PublishCommandTest extends BaseIngestionCommandTest {
       // when
       LaunchResult result = launcher.launch("publish",
           "--ingestion-url=" + getIngestionUrl(),
-          "-b=content='<h1>Hello World!</h1>'",
+          "-b=content.bytes=<h1>Hello!</h1>",
           CHANNEL, KEY);
 
       // then
       expectSuccess(result);
+      wm.verify(postRequestedFor(urlEqualTo(getPublicationPath(CHANNEL)))
+          .withRequestBody(equalToJson("""
+              {
+                "key" : "index.html",
+                "action" : "publish",
+                "eventTime" : null,
+                "properties" : { },
+                "payload" : {
+                  "dev.streamx.blueprints.data.Page" : {
+                    "content" : {
+                      "bytes" : "<h1>Hello!</h1>"
+                    }
+                  }
+                }
+              }
+              """))
+          .withoutHeader("Authorization"));
     }
 
     @Test

--- a/e2e-tests/src/test/java/dev/streamx/cli/StreamxCliPublicationIT.java
+++ b/e2e-tests/src/test/java/dev/streamx/cli/StreamxCliPublicationIT.java
@@ -98,6 +98,11 @@ public class StreamxCliPublicationIT {
             "Json exact page"
         ),
         arguments(
+            "json_path_exact_param_page.html",
+            "-b content.bytes='Json exact page'",
+            "Json exact page"
+        ),
+        arguments(
             "file_param_page.html",
             "-j file://" + absolutePath("file_param_page.json"),
             "file_param_page"

--- a/e2e-tests/src/test/java/dev/streamx/cli/StreamxCliPublicationIT.java
+++ b/e2e-tests/src/test/java/dev/streamx/cli/StreamxCliPublicationIT.java
@@ -106,6 +106,11 @@ public class StreamxCliPublicationIT {
             "json_path_file_param_page.html",
             "-s content.bytes=file://" + absolutePath("json_path_file_param_page.txt"),
             "json_path_file_param_page"
+        ),
+        arguments(
+            "json_path_file_param_page.html",
+            "-b content.bytes=file://" + absolutePath("json_path_file_param_page.txt"),
+            "json_path_file_param_page"
         )
     );
   }

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 
     <streamx.version>1.0.3</streamx.version>
     <streamx-operator.version>0.0.4</streamx-operator.version>
+    <avro.version>1.11.3</avro.version>
     <json-path.version>2.9.0</json-path.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <wiremock.version>3.10.0</wiremock.version>
@@ -82,6 +83,13 @@
         <artifactId>ingestion-client</artifactId>
         <version>${streamx.version}</version>
       </dependency>
+      <!-- This version needs to be same as in ingestion-client -->
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>dev.streamx</groupId>
         <artifactId>streamx-operator-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 
     <streamx.version>1.0.3</streamx.version>
     <streamx-operator.version>0.0.4</streamx-operator.version>
-    <avro.version>1.11.3</avro.version>
     <json-path.version>2.9.0</json-path.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <wiremock.version>3.10.0</wiremock.version>
@@ -82,12 +81,6 @@
         <groupId>dev.streamx</groupId>
         <artifactId>ingestion-client</artifactId>
         <version>${streamx.version}</version>
-      </dependency>
-      <!-- This version needs to be same as in ingestion-client -->
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>${avro.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [ ] Non-breaking change
- [x] Bug fix / minor change

## 🛠 Changes being made

* With bumping Quarkus version to >=3.14.0 Quarkus SBOM resolves Avro version to 1.12.0 which is different than ingestion-client's Avro version (1.11.3). This misversion causes wrong Binary serialization.  

## ✅ Checklist

- [ ] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [ ] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
